### PR TITLE
Expose QUEUE_DRAINED events on transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,53 @@ flowchart TD
     I -->|yes| F
     I -->|no| E
 ```
+## Nuances for self-closing pipelines
+
+TTS-only pipelines, as well as any other pipelines where the `EndFrame` is queued using `task.queue_frame(EndFrame())` or `task.stop_when_done()`, suffer from the problem that the `EndFrame` leads to a closure of the WebSocket to Asterisk without regard for whether the audio has yet been played to the caller on the other side. This leads Asterisk to tear down any simple bridges of which the WebSocket channel is a member, and thus to hang up on the caller.
+
+The `QUEUE_DRAINED` event (prompted by the `REPORT_QUEUE_DRAINED` command) is a robust solution to this problem. For convenience, `AsteriskWebsocketTransport` provides an async `wait_for_queue_drain()` method that can be `await`ed in your pipeline before closure:
+
+```python
+@app.websocket("/tts")
+async def tts_endpoint(websocket: WebSocket):
+    await websocket.accept()
+
+    ws_transport = AsteriskWebsocketTransport(websocket=websocket)
+
+    ...
+
+    pipeline = Pipeline([
+        ws_transport.input(),
+        tts,
+        ws_transport.output(),
+    ])
+
+    task = PipelineTask(pipeline)
+
+    # Run the pipeline, etc.
+
+    # Await queue drain on Asterisk side, then shut down.
+    await ws_transport.wait_for_queue_drain()
+    await task.stop_when_done()
+```
+
+Timing and order are important. One cannot send a `REPORT_QUEUE_DRAINED` request before media has actually been pushed to Asterisk's buffer, otherwise a `QUEUE_DRAINED` event will return immediately because the buffer is, as yet, empty. In practice, the execution of a pipeline as above may be bifurcated:
+
+```python
+@app.websocket("/tts")
+async def tts_endpoint(websocket: WebSocket):
+    ...
+    
+    runner = PipelineRunner(handle_sigint=False)
+    runner_task = asyncio.create_task(runner.run(task))
+
+    try:
+        await task.queue_frame(TTSSpeakFrame("Hello World"))
+        await ws_transport.wait_for_queue_drain()
+        await task.stop_when_done()
+        await runner_task # join async runner Task
+    except Exception:
+        runner_task.cancel()
+```
+
+Other elements would likely be required, such as a `FrameProcessor` that waits for a `TTSStoppedFrame` and fires an `asyncio.Event` or similar. These are beyond the scope of this project, but the clear intent is to say that calling `ws_transport.wait_for_queue_drain()` without being sure that something is remotely buffered first will likely not yield desired results.

--- a/src/pipecat_asterisk/serializer/serializer.py
+++ b/src/pipecat_asterisk/serializer/serializer.py
@@ -221,13 +221,12 @@ class AsteriskFrameSerializer(FrameSerializer):
         return None
 
     def _ev_queue_drained(self, message: dict) -> Frame | None:
-        # TODO: add REPORT_QUEUE_DRAINED support in the transport
         """QUEUE_DRAINED event handler.
 
         Handles QUEUE_DRAINED events from Asterisk. This event indicates that Asterisk has processed all the queued media.
-        We will only receive this event if we requested it by sending "REPORT_QUEUE_DRAINED", and only once per one "REPORT_QUEUE_DRAINED".
-        Effectively, this means that Asterisk stopped playing audio to the channel(bot stopped speaking), which might be good to know in Pipecat.
-        However, sending "REPORT_QUEUE_DRAINED" is currently (April 2026) not used by the transport, so you unlikely will receive this event.
+        We will only receive this event if we requested it by sending "REPORT_QUEUE_DRAINED", and only once per one 
+        "REPORT_QUEUE_DRAINED". Effectively, this means that Asterisk stopped playing audio to the channel(bot stopped speaking), 
+        which might be good to know in Pipecat.
 
         Args:
             message: The dictionary representing of the QUEUE_DRAINED event message from Asterisk.

--- a/src/pipecat_asterisk/serializer/serializer.py
+++ b/src/pipecat_asterisk/serializer/serializer.py
@@ -225,7 +225,7 @@ class AsteriskFrameSerializer(FrameSerializer):
 
         Handles QUEUE_DRAINED events from Asterisk. This event indicates that Asterisk has processed all the queued media.
         We will only receive this event if we requested it by sending "REPORT_QUEUE_DRAINED", and only once per one 
-        "REPORT_QUEUE_DRAINED". Effectively, this means that Asterisk stopped playing audio to the channel(bot stopped speaking), 
+        "REPORT_QUEUE_DRAINED". Effectively, this means that Asterisk stopped playing audio to the channel (bot stopped speaking), 
         which might be good to know in Pipecat.
 
         Args:

--- a/src/pipecat_asterisk/transport/transport.py
+++ b/src/pipecat_asterisk/transport/transport.py
@@ -92,6 +92,29 @@ class AsteriskWebsocketOutputTransport(FastAPIWebsocketOutputTransport):
                 f"{self} exception sending START_MEDIA_BUFFERING: {e.__class__.__name__} ({e})"
             )
 
+
+    """Ask Asterisk's `chan_websocket` to report QUEUE_DRAINED in the future, so that we know
+    when audio has been played out on the UX side.
+    """
+    async def _request_queue_drained(self):
+        if self._client.is_closing or not self._client.is_connected:
+            logger.warning(
+                f"Cannot send REPORT_QUEUE_DRAINED command because the WebSocket client is closing or already closed."
+            )
+            return
+        if not self._params.serializer:
+            logger.error(
+                f"Cannot send REPORT_QUEUE_DRAINED command because no serializer is set in the transport parameters."
+            )
+            return
+        try:
+            cmd = await self._params.serializer.serialize(AsteriskCommandFrame("REPORT_QUEUE_DRAINED"))
+            if cmd:
+                await self._client.send(cmd)
+                logger.info(f"Sent REPORT_QUEUE_DRAINED command to Asterisk WebSocket channel to enable audio buffering.")
+        except Exception as e:
+            logger.error(f"{self} exception sending REPORT_QUEUE_DRAINED: {e.__class__.__name__} ({e})")
+    
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         """Process outgoing frames.
 

--- a/src/pipecat_asterisk/transport/transport.py
+++ b/src/pipecat_asterisk/transport/transport.py
@@ -236,3 +236,6 @@ class AsteriskWebsocketTransport(FastAPIWebsocketTransport):
         self._output = AsteriskWebsocketOutputTransport(
             self, self._client, params, name=output_name
         )
+
+    def wait_for_queue_drain(self, timeout: int = 30):
+        return self._output._wait_for_queue_drain(timeout)

--- a/src/pipecat_asterisk/transport/transport.py
+++ b/src/pipecat_asterisk/transport/transport.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
+import asyncio
+import time
+
 from fastapi import WebSocket
 from loguru import logger
 from pipecat.transports.websocket.fastapi import (
@@ -93,7 +96,6 @@ class AsteriskWebsocketOutputTransport(FastAPIWebsocketOutputTransport):
                 f"{self} exception sending START_MEDIA_BUFFERING: {e.__class__.__name__} ({e})"
             )
 
-
     """Ask Asterisk's `chan_websocket` to report QUEUE_DRAINED in the future, so that we know
     when audio has been played out on the UX side.
     """
@@ -147,11 +149,13 @@ class AsteriskWebsocketOutputTransport(FastAPIWebsocketOutputTransport):
             # Drop any buffered audio in local and remote buffers to avoid replaying stale PCM
             if self._flow_controller:
                 self._flow_controller.drop_buffer()
-        elif (
-            isinstance(frame, InputTransportMessageFrame)
-            and frame.message.get("event", None) == "MEDIA_START"
-        ):
-            await self._media_start_handler(frame)
+        elif isinstance(frame, InputTransportMessageFrame):
+            ev_type = frame.message.get("event", None)
+            
+            if ev_type == "MEDIA_START":
+                await self._media_start_handler(frame)
+            elif ev_type == "QUEUE_DRAINED":
+                self._queue_drain_monitor.set()
 
     async def write_audio_frame(self, frame: OutputAudioRawFrame) -> bool:
         """Write an audio frame into local buffer.

--- a/src/pipecat_asterisk/transport/transport.py
+++ b/src/pipecat_asterisk/transport/transport.py
@@ -44,6 +44,7 @@ class AsteriskWebsocketOutputTransport(FastAPIWebsocketOutputTransport):
             )
         super().__init__(transport, client, params)
         self._flow_controller = None
+        self._queue_drain_monitor = asyncio.Event()
 
     async def _media_start_handler(self, frame: InputTransportMessageFrame):
         """Handle the MEDIA_START event.
@@ -114,7 +115,25 @@ class AsteriskWebsocketOutputTransport(FastAPIWebsocketOutputTransport):
                 logger.info(f"Sent REPORT_QUEUE_DRAINED command to Asterisk WebSocket channel to enable audio buffering.")
         except Exception as e:
             logger.error(f"{self} exception sending REPORT_QUEUE_DRAINED: {e.__class__.__name__} ({e})")
-    
+  
+    """Async-wait until queue drain monitor Event is fired.
+    """
+    async def _wait_for_queue_drain(self, timeout: int = 30):
+        await self._request_queue_drained()
+
+        logger.debug(f"Waiting for QUEUE_DRAINED report with a timeout of {timeout} sec")
+
+        start_time = time.monotonic()
+        
+        try:
+            await asyncio.wait_for(self._queue_drain_monitor.wait(), timeout=timeout)
+            elapsed_sec = time.monotonic() - start_time
+            logger.info(f"Received QUEUE_DRAINED report after {elapsed_sec:.2f} sec")
+        except asyncio.TimeoutError:
+            logger.debug("Timed out waiting for queue drain monitor")
+        finally:
+            self._queue_drain_monitor.clear()
+
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         """Process outgoing frames.
 


### PR DESCRIPTION
This PR adds:

* A facility for sending the `REPORT_QUEUE_DRAINED` command to Asterisk from the transport.
* A wrapper around the `asyncio.Event` primitive for waiting on `QUEUE_DRAINED` to be received, exposed as a convenience method from the high-level `AsteriskWebsocketTransport`.
* Documentation for how and why to use this, and patterns around it.