### PR TITLE
Move AsteriskCommandFrame to dedicated .frames namespace, as discussed

### DIFF
--- a/src/pipecat_asterisk/__init__.py
+++ b/src/pipecat_asterisk/__init__.py
@@ -8,4 +8,4 @@ from .serializer.serializer import AsteriskFrameSerializer, AsteriskCommandFrame
 from .transport.transport import AsteriskWebsocketTransport
 from .utils import FileAudioGenerator, WhiteNoiseGenerator
 
-__all__ = ["AsteriskFrameSerializer", "AsteriskCommandFrame", "AsteriskWebsocketTransport", "FileAudioGenerator", "WhiteNoiseGenerator"]
+__all__ = ["AsteriskFrameSerializer", "AsteriskWebsocketTransport", "FileAudioGenerator", "WhiteNoiseGenerator"]

--- a/src/pipecat_asterisk/__init__.py
+++ b/src/pipecat_asterisk/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-from .serializer.serializer import AsteriskFrameSerializer, AsteriskCommandFrame
+from .serializer.serializer import AsteriskFrameSerializer
 from .transport.transport import AsteriskWebsocketTransport
 from .utils import FileAudioGenerator, WhiteNoiseGenerator
 

--- a/src/pipecat_asterisk/frames/__init__.py
+++ b/src/pipecat_asterisk/frames/__init__.py
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2026, Nikolai Shakin
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+from .frames import AsteriskCommandFrame 
+
+__all__ = ["AsteriskCommandFrame"]

--- a/src/pipecat_asterisk/frames/frames.py
+++ b/src/pipecat_asterisk/frames/frames.py
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2026, Nikolai Shakin
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+from dataclasses import dataclass
+
+from pipecat.frames.frames import Frame
+
+@dataclass
+class AsteriskCommandFrame(Frame):
+    """A frame representing a command to be sent to Asterisk WebSocket channel."""
+    cmd: str
+

--- a/src/pipecat_asterisk/serializer/__init__.py
+++ b/src/pipecat_asterisk/serializer/__init__.py
@@ -5,6 +5,6 @@
 #
 
 from .protocol import AsteriskWSProtocol
-from .serializer import AsteriskFrameSerializer, AsteriskCommandFrame
+from .serializer import AsteriskFrameSerializer
 
-__all__ = ["AsteriskWSProtocol", "AsteriskFrameSerializer", "AsteriskCommandFrame"]
+__all__ = ["AsteriskWSProtocol", "AsteriskFrameSerializer"]

--- a/src/pipecat_asterisk/serializer/serializer.py
+++ b/src/pipecat_asterisk/serializer/serializer.py
@@ -23,6 +23,7 @@ from pipecat.frames.frames import (
 from pipecat.serializers.base_serializer import FrameSerializer
 
 from .protocol import AsteriskWSProtocol
+from ..frames import AsteriskCommandFrame
 
 class AsteriskFrameSerializer(FrameSerializer):
     """Asterisk WebSocket Serializer: Serializer for Asterisk WebSocket channel.

--- a/src/pipecat_asterisk/serializer/serializer.py
+++ b/src/pipecat_asterisk/serializer/serializer.py
@@ -24,12 +24,10 @@ from pipecat.serializers.base_serializer import FrameSerializer
 
 from .protocol import AsteriskWSProtocol
 
-
+@dataclass
 class AsteriskCommandFrame(Frame):
     """A frame representing a command to be sent to Asterisk WebSocket channel."""
-
-    def __init__(self, cmd: str):
-        self.cmd = cmd
+    cmd: str
 
 
 class AsteriskFrameSerializer(FrameSerializer):

--- a/src/pipecat_asterisk/serializer/serializer.py
+++ b/src/pipecat_asterisk/serializer/serializer.py
@@ -24,12 +24,6 @@ from pipecat.serializers.base_serializer import FrameSerializer
 
 from .protocol import AsteriskWSProtocol
 
-@dataclass
-class AsteriskCommandFrame(Frame):
-    """A frame representing a command to be sent to Asterisk WebSocket channel."""
-    cmd: str
-
-
 class AsteriskFrameSerializer(FrameSerializer):
     """Asterisk WebSocket Serializer: Serializer for Asterisk WebSocket channel.
 

--- a/src/pipecat_asterisk/transport/transport.py
+++ b/src/pipecat_asterisk/transport/transport.py
@@ -23,8 +23,8 @@ from pipecat.frames.frames import (
 )
 
 from .flow_controller import FlowController
-from ..serializer.serializer import AsteriskFrameSerializer, AsteriskCommandFrame
-
+from ..serializer.serializer import AsteriskFrameSerializer
+from ..frames import AsteriskCommandFrame
 
 class AsteriskWebsocketOutputTransport(FastAPIWebsocketOutputTransport):
     """Subclass of FastAPIWebsocketOutputTransport to handle Asterisk WebSocket channel communication."""


### PR DESCRIPTION
I'm behind this approach to waiting on `QUEUE_DRAINED`, so just following up on our discussion on the now-withdrawn PR and moving `AsteriskCommandFrame` to a dedicated import namespace:

```python
from pipecat_asterisk.frames import AsteriskCommandFrame
```

This is more consistent with how other Pipecat modules do things.

This PR is against the `add_cmd` branch, and I have cherry-picked your `@dataclass` change for the `AsteriskCommandFrame` definition, so it's incorporated here as well.